### PR TITLE
Change the priority of realIP detection

### DIFF
--- a/accesslog.go
+++ b/accesslog.go
@@ -126,6 +126,11 @@ func NewAroundLoggingMiddleware(logger Logger) func(http.Handler) http.Handler {
 // readIp return the real ip when behide nginx or apache
 func (h *LoggingHandler) realIp(r *http.Request) string {
 	// Check if behide nginx or apache
+	xRealIP := r.Header.Get("X-Real-Ip")
+	if xRealIP != "" {
+		return xRealIP
+	}
+
 	xForwardedFor := r.Header.Get("X-Forwarded-For")
 	for _, address := range strings.Split(xForwardedFor, ",") {
 		address = strings.TrimSpace(address)
@@ -134,14 +139,9 @@ func (h *LoggingHandler) realIp(r *http.Request) string {
 		}
 	}
 
-	xRealIP := r.Header.Get("X-Real-Ip")
-	if xRealIP != "" {
-		return xRealIP
-	}
-
 	ip, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
-		ip = r.RemoteAddr
+		return r.RemoteAddr
 	}
 	return ip
 }

--- a/accesslog.go
+++ b/accesslog.go
@@ -125,17 +125,8 @@ func NewAroundLoggingMiddleware(logger Logger) func(http.Handler) http.Handler {
 
 // readIp return the real ip when behide nginx or apache
 func (h *LoggingHandler) realIp(r *http.Request) string {
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		ip = r.RemoteAddr
-	}
-	if ip != "127.0.0.1" {
-		return ip
-	}
 	// Check if behide nginx or apache
-	xRealIP := r.Header.Get("X-Real-Ip")
 	xForwardedFor := r.Header.Get("X-Forwarded-For")
-
 	for _, address := range strings.Split(xForwardedFor, ",") {
 		address = strings.TrimSpace(address)
 		if address != "" {
@@ -143,8 +134,14 @@ func (h *LoggingHandler) realIp(r *http.Request) string {
 		}
 	}
 
+	xRealIP := r.Header.Get("X-Real-Ip")
 	if xRealIP != "" {
 		return xRealIP
+	}
+
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		ip = r.RemoteAddr
 	}
 	return ip
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mash/go-accesslog
+
+go 1.13


### PR DESCRIPTION
A nice feature of realIP has introduced at https://github.com/mash/go-accesslog/pull/3.

I want to adjust the detection way of it.

Currently, it seems to assume that proxy such as Nginx and Apache and Go applications are on the same host.

But, we often proxy directly from a proxy server on another host to Go applications so, I would like to give priority to X-Forwarded-For and X-Real-Ip Headers.

Also, I want it to support Go Modules, so can you tag a semver such as v0.1.0 to git after merge it? 

In addition, I'd be happy if you to place an appropriate LICENSE file.