### PR TITLE
add go.mod for introducing go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mash/go-accesslog
+
+go 1.13


### PR DESCRIPTION
This pull request is separated from https://github.com/mash/go-accesslog/pull/5.

Can you tag a semver such as v0.1.0 to git after merge it? In addition, I'd be happy if you to place an appropriate LICENSE file.